### PR TITLE
Wait and retry when receiving a 429 or 5xx response

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,7 +3,6 @@ package dropbox
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -84,16 +83,16 @@ request_loop:
 		res, err = c.HTTPClient.Do(req)
 		switch res.StatusCode {
 		case 429:
-			log.Print(fmt.Sprintf("Received Retry status code %d.", res.StatusCode))
+			log.Printf("Received Retry status code %d.", res.StatusCode)
 			sleep_time, conv_e := strconv.Atoi(res.Header.Get("Retry-After"))
 			if conv_e != nil {
 				sleep_time = 60
 			}
-			log.Print(fmt.Sprintf("Sleeping for %d seconds.", sleep_time))
+			log.Printf("Sleeping for %d seconds.", sleep_time)
 			time.Sleep(time.Duration(sleep_time) * time.Second)
 		case 500:
-			log.Print(fmt.Sprintf("Received Error status code %d.", res.StatusCode))
-			log.Print(fmt.Sprintf("Sleeping for %d seconds.", error_retry_time))
+			log.Printf("Received Error status code %d.", res.StatusCode)
+			log.Printf("Sleeping for %d seconds.", error_retry_time)
 			time.Sleep(time.Duration(error_retry_time) * time.Second)
 			error_retry_time *= 1.5
 		default:
@@ -101,12 +100,12 @@ request_loop:
 		}
 	}
 	if err != nil {
-		log.Print(fmt.Sprintf("URL: %s - Method: %s", req.URL, req.Method))
-		log.Print(fmt.Sprintf("HTTP Error StatusCode %d", res.StatusCode))
+		log.Printf("URL: %s - Method: %s", req.URL, req.Method)
+		log.Printf("HTTP Error StatusCode %d", res.StatusCode)
 		if b, err := ioutil.ReadAll(res.Body); err == nil {
 			log.Print(string(b))
 		} else {
-			log.Print(fmt.Sprintf("Error reading body: %s", err))
+			log.Printf("Error reading body: %s", err)
 
 		}
 		return nil, 0, err
@@ -128,8 +127,8 @@ request_loop:
 	if strings.Contains(kind, "text/plain") {
 		if b, err := ioutil.ReadAll(res.Body); err == nil {
 			e.Summary = string(b)
-			log.Print(fmt.Sprintf("URL: %s - Method: %s", req.URL, req.Method))
-			log.Print(fmt.Sprintf("HTTP StatusCode %d", res.StatusCode))
+			log.Printf("URL: %s - Method: %s", req.URL, req.Method)
+			log.Printf("HTTP StatusCode %d", res.StatusCode)
 			log.Print(e.Summary)
 			return nil, 0, e
 		} else {
@@ -138,13 +137,13 @@ request_loop:
 	}
 
 	if err := json.NewDecoder(res.Body).Decode(e); err != nil {
-		log.Print(fmt.Sprintf("URL: %s - Method: %s", req.URL, req.Method))
-		log.Print(fmt.Sprintf("HTTP StatusCode %d", res.StatusCode))
+		log.Printf("URL: %s - Method: %s", req.URL, req.Method)
+		log.Printf("HTTP StatusCode %d", res.StatusCode)
 		log.Print(e.Summary)
 		return nil, 0, err
 	}
-	log.Print(fmt.Sprintf("URL: %s - Method: %s", req.URL, req.Method))
-	log.Print(fmt.Sprintf("HTTP StatusCode %d", res.StatusCode))
+	log.Printf("URL: %s - Method: %s", req.URL, req.Method)
+	log.Printf("HTTP StatusCode %d", res.StatusCode)
 	log.Print(e.Summary)
 	return nil, 0, e
 }

--- a/client.go
+++ b/client.go
@@ -3,10 +3,14 @@ package dropbox
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // Client implements a Dropbox client. You may use the Files and Users
@@ -72,8 +76,39 @@ func (c *Client) download(path string, in interface{}, r io.Reader) (io.ReadClos
 
 // perform the request.
 func (c *Client) do(req *http.Request) (io.ReadCloser, int64, error) {
-	res, err := c.HTTPClient.Do(req)
+	var err error
+	var res *http.Response
+	error_retry_time := 0.5
+request_loop:
+	for error_retry_time < 300 {
+		res, err = c.HTTPClient.Do(req)
+		switch res.StatusCode {
+		case 429:
+			log.Print(fmt.Sprintf("Received Retry status code %d.", res.StatusCode))
+			sleep_time, conv_e := strconv.Atoi(res.Header.Get("Retry-After"))
+			if conv_e != nil {
+				sleep_time = 60
+			}
+			log.Print(fmt.Sprintf("Sleeping for %d seconds.", sleep_time))
+			time.Sleep(time.Duration(sleep_time) * time.Second)
+		case 500:
+			log.Print(fmt.Sprintf("Received Error status code %d.", res.StatusCode))
+			log.Print(fmt.Sprintf("Sleeping for %d seconds.", error_retry_time))
+			time.Sleep(time.Duration(error_retry_time) * time.Second)
+			error_retry_time *= 1.5
+		default:
+			break request_loop
+		}
+	}
 	if err != nil {
+		log.Print(fmt.Sprintf("URL: %s - Method: %s", req.URL, req.Method))
+		log.Print(fmt.Sprintf("HTTP Error StatusCode %d", res.StatusCode))
+		if b, err := ioutil.ReadAll(res.Body); err == nil {
+			log.Print(string(b))
+		} else {
+			log.Print(fmt.Sprintf("Error reading body: %s", err))
+
+		}
 		return nil, 0, err
 	}
 
@@ -93,6 +128,9 @@ func (c *Client) do(req *http.Request) (io.ReadCloser, int64, error) {
 	if strings.Contains(kind, "text/plain") {
 		if b, err := ioutil.ReadAll(res.Body); err == nil {
 			e.Summary = string(b)
+			log.Print(fmt.Sprintf("URL: %s - Method: %s", req.URL, req.Method))
+			log.Print(fmt.Sprintf("HTTP StatusCode %d", res.StatusCode))
+			log.Print(e.Summary)
 			return nil, 0, e
 		} else {
 			return nil, 0, err
@@ -100,8 +138,13 @@ func (c *Client) do(req *http.Request) (io.ReadCloser, int64, error) {
 	}
 
 	if err := json.NewDecoder(res.Body).Decode(e); err != nil {
+		log.Print(fmt.Sprintf("URL: %s - Method: %s", req.URL, req.Method))
+		log.Print(fmt.Sprintf("HTTP StatusCode %d", res.StatusCode))
+		log.Print(e.Summary)
 		return nil, 0, err
 	}
-
+	log.Print(fmt.Sprintf("URL: %s - Method: %s", req.URL, req.Method))
+	log.Print(fmt.Sprintf("HTTP StatusCode %d", res.StatusCode))
+	log.Print(e.Summary)
 	return nil, 0, e
 }

--- a/files.go
+++ b/files.go
@@ -63,7 +63,7 @@ func (c *Files) GetMetadata(in *GetMetadataInput) (out *GetMetadataOutput, err e
 
 	err = json.NewDecoder(body).Decode(&out)
 
-        ioutil.ReadAll(body)
+	ioutil.ReadAll(body)
 	return
 }
 
@@ -88,7 +88,7 @@ func (c *Files) CreateFolder(in *CreateFolderInput) (out *CreateFolderOutput, er
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
-        ioutil.ReadAll(body)
+	ioutil.ReadAll(body)
 	return
 }
 
@@ -111,7 +111,7 @@ func (c *Files) Delete(in *DeleteInput) (out *DeleteOutput, err error) {
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
-        ioutil.ReadAll(body)
+	ioutil.ReadAll(body)
 	return
 }
 
@@ -127,7 +127,7 @@ func (c *Files) PermanentlyDelete(in *PermanentlyDeleteInput) (err error) {
 		return
 	}
 	defer body.Close()
-        ioutil.ReadAll(body)
+	ioutil.ReadAll(body)
 
 	return
 }
@@ -152,7 +152,7 @@ func (c *Files) Copy(in *CopyInput) (out *CopyOutput, err error) {
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
-        ioutil.ReadAll(body)
+	ioutil.ReadAll(body)
 	return
 }
 
@@ -176,7 +176,7 @@ func (c *Files) Move(in *MoveInput) (out *MoveOutput, err error) {
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
-        ioutil.ReadAll(body)
+	ioutil.ReadAll(body)
 	return
 }
 
@@ -200,7 +200,7 @@ func (c *Files) Restore(in *RestoreInput) (out *RestoreOutput, err error) {
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
-        ioutil.ReadAll(body)
+	ioutil.ReadAll(body)
 	return
 }
 
@@ -230,7 +230,7 @@ func (c *Files) ListFolder(in *ListFolderInput) (out *ListFolderOutput, err erro
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
-        ioutil.ReadAll(body)
+	ioutil.ReadAll(body)
 	return
 }
 
@@ -248,7 +248,7 @@ func (c *Files) ListFolderContinue(in *ListFolderContinueInput) (out *ListFolder
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
-        ioutil.ReadAll(body)
+	ioutil.ReadAll(body)
 	return
 }
 
@@ -311,7 +311,7 @@ func (c *Files) Search(in *SearchInput) (out *SearchOutput, err error) {
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
-        ioutil.ReadAll(body)
+	ioutil.ReadAll(body)
 	return
 }
 
@@ -339,7 +339,7 @@ func (c *Files) Upload(in *UploadInput) (out *UploadOutput, err error) {
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
-        ioutil.ReadAll(body)
+	ioutil.ReadAll(body)
 	return
 }
 
@@ -461,7 +461,7 @@ func (c *Files) ListRevisions(in *ListRevisionsInput) (out *ListRevisionsOutput,
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
-        ioutil.ReadAll(body)
+	ioutil.ReadAll(body)
 	return
 }
 


### PR DESCRIPTION
Wait and retry when receiving a 429 Retry-After response instead of failing. This prevents abuse and allows the use of multiple threads.

Retry with backoff on 5xx errors. These are often transient and should not cause a large backup to fail.