### PR TITLE
Retry on all 5xx errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -83,16 +82,12 @@ request_loop:
 		res, err = c.HTTPClient.Do(req)
 		switch {
 		case res.StatusCode == 429:
-			log.Print("Received Retry status code %d.", res.StatusCode)
 			sleep_time, conv_e := strconv.Atoi(res.Header.Get("Retry-After"))
 			if conv_e != nil {
 				sleep_time = 60
 			}
-			log.Printf("Sleeping for %d seconds.", sleep_time)
 			time.Sleep(time.Duration(sleep_time) * time.Second)
 		case res.StatusCode >= 500: // Retry on 5xx
-			log.Printf("Received Error status code %d.", res.StatusCode)
-			log.Printf("Sleeping for %d seconds.", error_retry_time)
 			time.Sleep(time.Duration(error_retry_time) * time.Second)
 			error_retry_time *= 1.5
 		default:
@@ -100,14 +95,6 @@ request_loop:
 		}
 	}
 	if err != nil {
-		log.Printf("URL: %s - Method: %s", req.URL, req.Method)
-		log.Printf("HTTP Error StatusCode %d", res.StatusCode)
-		if b, err := ioutil.ReadAll(res.Body); err == nil {
-			log.Print(string(b))
-		} else {
-			log.Printf("Error reading body: %s", err)
-
-		}
 		return nil, 0, err
 	}
 
@@ -127,9 +114,6 @@ request_loop:
 	if strings.Contains(kind, "text/plain") {
 		if b, err := ioutil.ReadAll(res.Body); err == nil {
 			e.Summary = string(b)
-			log.Printf("URL: %s - Method: %s", req.URL, req.Method)
-			log.Printf("HTTP StatusCode %d", res.StatusCode)
-			log.Print(e.Summary)
 			return nil, 0, e
 		} else {
 			return nil, 0, err
@@ -137,13 +121,7 @@ request_loop:
 	}
 
 	if err := json.NewDecoder(res.Body).Decode(e); err != nil {
-		log.Printf("URL: %s - Method: %s", req.URL, req.Method)
-		log.Printf("HTTP StatusCode %d", res.StatusCode)
-		log.Print(e.Summary)
 		return nil, 0, err
 	}
-	log.Printf("URL: %s - Method: %s", req.URL, req.Method)
-	log.Printf("HTTP StatusCode %d", res.StatusCode)
-	log.Print(e.Summary)
 	return nil, 0, e
 }

--- a/client.go
+++ b/client.go
@@ -81,16 +81,16 @@ func (c *Client) do(req *http.Request) (io.ReadCloser, int64, error) {
 request_loop:
 	for error_retry_time < 300 {
 		res, err = c.HTTPClient.Do(req)
-		switch res.StatusCode {
-		case 429:
-			log.Printf("Received Retry status code %d.", res.StatusCode)
+		switch {
+		case res.StatusCode == 429:
+			log.Print("Received Retry status code %d.", res.StatusCode)
 			sleep_time, conv_e := strconv.Atoi(res.Header.Get("Retry-After"))
 			if conv_e != nil {
 				sleep_time = 60
 			}
 			log.Printf("Sleeping for %d seconds.", sleep_time)
 			time.Sleep(time.Duration(sleep_time) * time.Second)
-		case 500:
+		case res.StatusCode >= 500: // Retry on 5xx
 			log.Printf("Received Error status code %d.", res.StatusCode)
 			log.Printf("Sleeping for %d seconds.", error_retry_time)
 			time.Sleep(time.Duration(error_retry_time) * time.Second)

--- a/files.go
+++ b/files.go
@@ -60,10 +60,10 @@ func (c *Files) GetMetadata(in *GetMetadataInput) (out *GetMetadataOutput, err e
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
 
-	ioutil.ReadAll(body)
 	return
 }
 
@@ -86,9 +86,9 @@ func (c *Files) CreateFolder(in *CreateFolderInput) (out *CreateFolderOutput, er
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
-	ioutil.ReadAll(body)
 	return
 }
 
@@ -109,9 +109,9 @@ func (c *Files) Delete(in *DeleteInput) (out *DeleteOutput, err error) {
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
-	ioutil.ReadAll(body)
 	return
 }
 
@@ -127,7 +127,7 @@ func (c *Files) PermanentlyDelete(in *PermanentlyDeleteInput) (err error) {
 		return
 	}
 	defer body.Close()
-	ioutil.ReadAll(body)
+	defer ioutil.ReadAll(body)
 
 	return
 }
@@ -150,9 +150,9 @@ func (c *Files) Copy(in *CopyInput) (out *CopyOutput, err error) {
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
-	ioutil.ReadAll(body)
 	return
 }
 
@@ -174,9 +174,9 @@ func (c *Files) Move(in *MoveInput) (out *MoveOutput, err error) {
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
-	ioutil.ReadAll(body)
 	return
 }
 
@@ -198,9 +198,9 @@ func (c *Files) Restore(in *RestoreInput) (out *RestoreOutput, err error) {
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
-	ioutil.ReadAll(body)
 	return
 }
 
@@ -228,9 +228,9 @@ func (c *Files) ListFolder(in *ListFolderInput) (out *ListFolderOutput, err erro
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
-	ioutil.ReadAll(body)
 	return
 }
 
@@ -246,9 +246,9 @@ func (c *Files) ListFolderContinue(in *ListFolderContinueInput) (out *ListFolder
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
-	ioutil.ReadAll(body)
 	return
 }
 
@@ -309,9 +309,9 @@ func (c *Files) Search(in *SearchInput) (out *SearchOutput, err error) {
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
-	ioutil.ReadAll(body)
 	return
 }
 
@@ -337,9 +337,9 @@ func (c *Files) Upload(in *UploadInput) (out *UploadOutput, err error) {
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
-	ioutil.ReadAll(body)
 	return
 }
 
@@ -459,9 +459,9 @@ func (c *Files) ListRevisions(in *ListRevisionsInput) (out *ListRevisionsOutput,
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
-	ioutil.ReadAll(body)
 	return
 }
 

--- a/sharing.go
+++ b/sharing.go
@@ -2,6 +2,7 @@ package dropbox
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"time"
 )
 
@@ -54,6 +55,7 @@ func (c *Sharing) CreateSharedLink(in *CreateSharedLinkInput) (out *CreateShared
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
 	return

--- a/users.go
+++ b/users.go
@@ -2,6 +2,7 @@ package dropbox
 
 import (
 	"encoding/json"
+	"io/ioutil"
 )
 
 // Users client for user accounts.
@@ -41,6 +42,7 @@ func (c *Users) GetAccount(in *GetAccountInput) (out *GetAccountOutput, err erro
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
 	return
@@ -72,6 +74,7 @@ func (c *Users) GetCurrentAccount() (out *GetCurrentAccountOutput, err error) {
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
 	return
@@ -93,6 +96,7 @@ func (c *Users) GetSpaceUsage() (out *GetSpaceUsageOutput, err error) {
 		return
 	}
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 
 	err = json.NewDecoder(body).Decode(&out)
 	return


### PR DESCRIPTION
Retry on all 5xx errors (eg: 502)

Use `defer` to read the http.Response.Body before closing for all operations, this allows the keepalive connection to be reused by http.Client.

Remove noisy logging.