### PR TITLE
Fix refreshing access token after expiration

### DIFF
--- a/client.go
+++ b/client.go
@@ -125,6 +125,7 @@ request_loop:
         case res.StatusCode == 401:
 			log.Printf("[DROPBOX_RETRY] %s %s returned %d; refreshing access token", req.Method, req.URL, res.StatusCode, error_retry_time)
 			err = c.refreshToken()
+			req.Header.Set("Authorization", "Bearer "+c.AccessToken)
 			if err != nil {
 				log.Printf("[DROPBOX_RETRY] %s returned an error: %v", c.RefreshURL, err)
 				time.Sleep(time.Duration(error_retry_time) * time.Second)
@@ -214,6 +215,7 @@ func (client *Client) refreshToken() (err error) {
 	if client.Token.AccessToken == "" {
 		return fmt.Errorf("No access token returned")
 	}
+	
 	client.AccessToken = client.Token.AccessToken
 
 	return nil

--- a/client.go
+++ b/client.go
@@ -188,6 +188,7 @@ func (client *Client) refreshToken() (err error) {
 		return nil
 	}
 
+	client.Token.AccessToken = ""
 	client.Token.RefreshToken = client.RefreshToken
 	body, err := json.Marshal(client.Token)
 	if err != nil {


### PR DESCRIPTION
The refresh endpoint that duplicacy is using (https://duplicacy.com/dropbox_refresh) doesn't appear to refresh the token if there is an existing access token passed in the body of the request (regardless of its `Expiry` value). This forces it to be blank before performing the refresh.

Also, must change the auth header after refreshing the access token else it will just loop forever.